### PR TITLE
Adapted naming for u901/u902 to A4000T convention

### DIFF
--- a/A4000D/source/u901.pld
+++ b/A4000D/source/u901.pld
@@ -10,51 +10,68 @@ DEVICE          g16v8 ;
 
 /* IDECODE */
 
-/** PINS **/
-PIN   1  =  AS_;
-PIN   2  =  DS;
+/** Inputs **/
+PIN   1  =  !AS;
+PIN   2  =  !DS;
 PIN   3  =  A12;
 PIN   4  =  A13;
 PIN   5  =  A1;
-PIN   6  =  SCSI;
+PIN   6  =  !SCSI;
 PIN   7  =  CPUBCLK;
 
-PIN  12  =  AS;
-PIN  13  =  SOME_EN;
-PIN  14  =  DSACK1;
-PIN  15  =  INTREG1;
-PIN  16  =  INTREG2;
-PIN  17  =  IDE_CS2;
-PIN  18  =  IDE_CS1;
-PIN  19  =  IDE_IREG;
+/** Outputs **/
+PIN  12  =  !nAS;
+PIN  13  =  !ACCESS;
+PIN  14  =  !DSACK1;
+PIN  15  =  !DLY_AS1;
+PIN  16  =  !DLY_AS2;
+PIN  17  =  !IDE_CS2;
+PIN  18  =  !IDE_CS1;
+PIN  19  =  !IDE_IREG; /* HD_STAT */
 
-!IDE_IREG = !DS & A12 & A13 & !A1 & !SCSI;
-IDE_IREG.oe = 'b'1;
+/** Declarations and Intermediate Variable Definitions  **/
 
-!IDE_CS1 = !A12 & A13 & !SCSI
-    # AS_ & !IDE_CS1;
-IDE_CS1.oe = 'b'1;
+EN = 'b'1;
 
-!IDE_CS2 = A12 & A13 & A1 & !SCSI
-    # AS_ & !IDE_CS2;
-IDE_CS2.oe = 'b'1;
+/** Logic Equations **/
 
-!INTREG2 = INTREG2 & !INTREG1 & !CPUBCLK
-    # !INTREG2 & !INTREG1;
-INTREG2.oe = 'b'1;
+/* AS delay 1 */
+DLY_AS1 = AS & !DLY_AS1 & CPUBCLK
+    # AS & DLY_AS1;
+DLY_AS1.oe = EN;
 
-!INTREG1 = !AS_ & INTREG1 & CPUBCLK
-    # !AS_ & !INTREG1;
-INTREG1.oe = 'b'1;
+/* AS delay 2 */
+DLY_AS2 = !DLY_AS2 & DLY_AS1 & !CPUBCLK
+    # DLY_AS2 & DLY_AS1;
+DLY_AS2.oe = EN;
 
-!DSACK1 = !AS_ & A12 & A13 & !A1 & !SCSI;
-DSACK1.oe = A12 & A13 & !A1 & !SCSI & !INTREG1;
+/* select signal for interrupt state */
+/* DD3000, DD3001, DD3004, DD3005, ... D3FFC, D3FFD */
+IDE_IREG = DS & A13 & A12 & !A1 & SCSI; /* should be AS instead of DS */
+IDE_IREG.oe = EN;
 
-!SOME_EN = A12 & A13 & A1 & !INTREG2 & !SCSI & CPUBCLK
-    # !A12 & A13 & !INTREG2 & !SCSI & CPUBCLK
-    # !AS_ & !SOME_EN
-    # !CPUBCLK & !SOME_EN;
-SOME_EN.oe = 'b'1;
+/* chip select for first IDE controller (and data register) */
+/* DD2000-DD2FFF */
+IDE_CS1 =  A13 & !A12 & SCSI
+         # !AS & IDE_CS1;     /* should be AS instead of !AS ? */
+IDE_CS1.oe = EN;
 
-!AS = AS_;
-AS.oe = 'b'1;
+/* chip select for second IDE controller */
+/* DD3002, DD3003, DD3006, DD3007, ... D3FFE, D3FFF */
+IDE_CS2 =   A13 & A12 & A1 & SCSI
+         # !AS & IDE_CS2;     /* should be AS instead of !AS ? */
+IDE_CS2.oe = EN;
+
+/* DSACK1 for 16bit interrupt status register access */
+DSACK1    = A13 & A12 & !A1 & SCSI & AS ;
+DSACK1.oe = A13 & A12 & !A1 & SCSI & DLY_AS1;
+
+/* IDE access phase */
+ACCESS =  A13 &  A12 & A1 &  DLY_AS2 & SCSI & CPUBCLK /* CS2 */
+        # A13 & !A12 &       DLY_AS2 & SCSI & CPUBCLK /* CS1 */
+        # AS & ACCESS
+        # !CPUBCLK & ACCESS;
+ACCESS.oe = EN;
+
+nAS = !AS;
+nAS.oe = EN;

--- a/A4000D/source/u902.pld
+++ b/A4000D/source/u902.pld
@@ -6,77 +6,85 @@ DESIGNER        Dave Haynie ;
 COMPANY         Commodore ;
 ASSEMBLY        A4000D ;
 LOCATION        West Chester ;
-DEVICE          g16v8ms ;
+DEVICE          g16v8 ;
 
 /* istate */
 
-PIN  1   =  CLK ;
-PIN  2   =  SOME_ENABLE ;
-PIN  3   =  A13 ; /* unused? */
-PIN  4   =  AS_ ;
+/** Inputs **/
+PIN  1   =  CLK ; /* = CPUBCLK */
+PIN  2   =  !ACCESS ;
+PIN  3   =  A13 ; /* unused */
+PIN  4   =  !AS ;
 PIN  5   =  R_W ;
 PIN  6   =  A1 ;
-PIN  7   =  IDE_IREG ;
+PIN  7   =  !IDE_IREG ; /* HD_STAT */
 PIN  8   =  CPUBCLK ;
-PIN  9   =  IDE_INT ;
-PIN 11   =  !OE ;
+PIN  9   =  !IDE_INT ;
+/* PIN 11   =  !OE ; */ /* hard wired as OE in registered mode */
+
+/** Outputs **/
 PIN 12   =  D31 ;
-PIN 13   =  INTREG1 ;
-PIN 14   =  INTREG2 ;
-PIN 15   =  INTREG3 ;
-PIN 16   =  INTREG4 ;
-PIN 17   =  IOR ;
-PIN 18   =  IOW ;
-PIN 19   =  DSACK1 ;
+PIN 13   =  !SVAR_D ;
+PIN 14   =  !SVAR_C ;
+PIN 15   =  !SVAR_B ;
+PIN 16   =  !SVAR_A ;
+PIN 17   =  !IOR ;
+PIN 18   =  !IOW ;
+PIN 19   =  !DSACK1 ;
 
-!DSACK1 = !SOME_ENABLE & !DSACK1 & !AS_
-    # !SOME_ENABLE & !IOW & IOR & INTREG4 & !INTREG3 & !INTREG2 & !CPUBCLK & !INTREG1
-    # !SOME_ENABLE & IOW & !IOR & INTREG4 & !INTREG3 & INTREG2 & !CPUBCLK & !INTREG1
-    # !SOME_ENABLE & IOW & !IOR & INTREG4 & !A1 & INTREG3 & !INTREG2 & !CPUBCLK & !INTREG1
-    # !SOME_ENABLE & !IOW & IOR & INTREG4 & !A1 & INTREG3 & !INTREG2 & !CPUBCLK & INTREG1;
-DSACK1.oe = !SOME_ENABLE;
+/* IDE state machine */
+SVAR_A.d =  !IOW & !IOR &  SVAR_A &  SVAR_B & !SVAR_C
+          # !IOW & !IOR &  SVAR_A &  SVAR_B &            SVAR_D
+          # !IOW & !IOR & !SVAR_A &  SVAR_B &  SVAR_C & !SVAR_D;
+/* SVAR_A.oe = OE; */
 
-!IOW.d = !IOW & IOR & INTREG4 & INTREG3
-    # !IOW & IOR & INTREG4 & !INTREG1
-    # !IOW & IOR & INTREG4 & A1 & INTREG2
-    # IOR & !R_W & INTREG4 & INTREG3 & INTREG2 & !INTREG1;
-/* IOW.oe = OE; // Implicit */
+SVAR_B.d =  !IOR &        !SVAR_A &  SVAR_B
+          # !IOW &        !SVAR_A &  SVAR_B
+          # !IOW & !IOR &            SVAR_B & !SVAR_C
+          # !IOW & !IOR &            SVAR_B &            SVAR_D
+          #  IOW & !IOR & !SVAR_A &            SVAR_C & !SVAR_D
+          # !IOW &  IOR & !SVAR_A &            SVAR_C & !SVAR_D;
+/* SVAR_B.oe = OE; */
 
-!IOR.d = IOW & !IOR & INTREG4 & INTREG3
-    # IOW & !IOR & INTREG4 & !INTREG1
-    # IOW & !IOR & INTREG4 & A1 & INTREG2
-    # IOW & R_W & INTREG4 & INTREG3 & INTREG2 & !INTREG1;
-/* IOR.oe = OE; // Implicit */
+SVAR_C.d =   IOW & !IOR & !SVAR_A &                      SVAR_D
+          # !IOW &  IOR & !SVAR_A &                      SVAR_D
+          # !IOW & !IOR &            SVAR_B &            SVAR_D
+          #  IOW & !IOR & !SVAR_A &  SVAR_B &  SVAR_C
+          # !IOW &  IOR & !SVAR_A &  SVAR_B &  SVAR_C;
+/* SVAR_C.oe = OE; */
 
-!INTREG4.d = IOW & IOR & !INTREG4 & !INTREG3 & INTREG2
-    # IOW & IOR & !INTREG4 & !INTREG3 & !INTREG1
-    # IOW & IOR & INTREG4 & !INTREG3 & !INTREG2 & INTREG1;
-/* INTREG4.oe = OE; // Implicit */
+SVAR_D.d =  !IOW & !IOR &            SVAR_B & !SVAR_C
+          #  IOW & !IOR & !SVAR_A &           !SVAR_C           & A1 
+          # !IOW &  IOR & !SVAR_A &           !SVAR_C           & A1
+          #  IOW & !IOR & !SVAR_A & !SVAR_B & !SVAR_C
+          # !IOW &  IOR & !SVAR_A & !SVAR_B & !SVAR_C
+          #  IOW & !IOR & !SVAR_A &           !SVAR_C &  SVAR_D
+          # !IOW &  IOR & !SVAR_A &           !SVAR_C &  SVAR_D
+          # !IOW & !IOR & !SVAR_A &           !SVAR_C & !SVAR_D & ACCESS;               /* ACCESS1 */
+/* SVAR_D.oe = OE; */
 
-!INTREG3.d = IOR & INTREG4 & !INTREG3
-    # IOW & INTREG4 & !INTREG3
-    # IOW & IOR & !INTREG3 & INTREG2
-    # IOW & IOR & !INTREG3 & !INTREG1
-    # !IOW & IOR & INTREG4 & !INTREG2 & INTREG1
-    # IOW & !IOR & INTREG4 & !INTREG2 & INTREG1;
-/* INTREG3.oe = OE; // Implicit */
+/* 16bit cycle termination */
+DSACK1 = ACCESS & DSACK1 & AS
+    # !CPUBCLK & ACCESS &  IOW & !IOR &       !SVAR_A &  SVAR_B &  SVAR_C &  SVAR_D
+    # !CPUBCLK & ACCESS & !IOW &  IOR &       !SVAR_A &  SVAR_B & !SVAR_C &  SVAR_D
+    # !CPUBCLK & ACCESS & !IOW &  IOR & !A1 & !SVAR_A & !SVAR_B &  SVAR_C &  SVAR_D
+    # !CPUBCLK & ACCESS &  IOW & !IOR & !A1 & !SVAR_A & !SVAR_B &  SVAR_C & !SVAR_D;
+DSACK1.oe = ACCESS;
 
-!INTREG2.d = !IOW & IOR & INTREG4 & !INTREG1
-    # IOW & !IOR & INTREG4 & !INTREG1
-    # IOW & IOR & !INTREG3 & !INTREG1
-    # !IOW & IOR & INTREG4 & !INTREG3 & !INTREG2
-    # IOW & !IOR & INTREG4 & !INTREG3 & !INTREG2;
-/* INTREG2.oe = OE; // Implicit */
+/* read signal for IDE */
+IOR.d =  !IOW &  IOR & !SVAR_A & !SVAR_B
+       # !IOW &  IOR & !SVAR_A &                      SVAR_D
+       # !IOW &  IOR & !SVAR_A &           !SVAR_C &            A1
+       # !IOW &        !SVAR_A & !SVAR_B & !SVAR_C &  SVAR_D &  R_W;
+/* IOR.oe = OE; */
 
-!INTREG1.d = IOW & IOR & !INTREG3 & INTREG2
-    # !IOW & IOR & INTREG4 & A1 & INTREG2
-    # IOW & !IOR & INTREG4 & A1 & INTREG2
-    # !IOW & IOR & INTREG4 & INTREG3 & INTREG2
-    # IOW & !IOR & INTREG4 & INTREG3 & INTREG2
-    # !IOW & IOR & INTREG4 & INTREG2 & !INTREG1
-    # IOW & !IOR & INTREG4 & INTREG2 & !INTREG1
-    # !SOME_ENABLE & IOW & IOR & INTREG4 & INTREG2 & INTREG1;
-/* INTREG1.oe = OE; // Implicit */
+/* write signal for IDE */
+IOW.d =   IOW & !IOR & !SVAR_A & !SVAR_B
+       #  IOW & !IOR & !SVAR_A &                      SVAR_D
+       #  IOW & !IOR & !SVAR_A &           !SVAR_C &            A1
+       #        !IOR & !SVAR_A & !SVAR_B & !SVAR_C &  SVAR_D & !R_W ;
+/* IOW.oe = OE; */
 
-!D31 = IDE_INT;
-D31.oe = !IDE_IREG;
+/* read IDE interrupt signal */
+D31 = IDE_INT;
+D31.oe = IDE_IREG;


### PR DESCRIPTION
- inverted inputs/outputs
- use A4000T naming for unnamed inputs/outputs
- comment possible bugs